### PR TITLE
Add feature for Serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,18 @@ documentation = "https://docs.rs/rpmrepo_metadata/"
 [features]
 python_ext = ["pyo3"]
 read_rpm = ["rpm"]
+serde = ["dep:serde", "indexmap/serde"]
 
 [dependencies]
 quick-xml = { version = "0.23.0", default-features = false }
 # rayon = "1.5.1"
 thiserror = "1.0.40"
-niffler = { version = "2.5.0", features = ["bz2", "xz", "gz", "zstd"], default-features = false }
+niffler = { version = "2.5.0", features = [
+    "bz2",
+    "xz",
+    "gz",
+    "zstd",
+], default-features = false }
 rpm = { version = "0.12.0", default-features = false, optional = true }
 # tempdir = "0.3.7"
 digest = "0.10.6"
@@ -30,6 +36,7 @@ md-5 = "0.10.5"
 hex = "0.4.3"
 indexmap = "2.0.0"
 pyo3 = { version = "0.20.0", features = ["extension-module"], optional = true }
+serde = { version = "1.0.203", features = ["derive"], optional = true }
 
 [lib]
 name = "rpmrepo_metadata"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 
@@ -22,7 +24,7 @@ use std::fmt;
 /// not directly associated with an upstream release and will force it to sort higher, e.g.
 /// 0.5.0 vs 0.5.0^deadbeef
 #[derive(Clone, Debug, Default, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EVR {
     pub epoch: String,
     pub version: String,

--- a/src/common.rs
+++ b/src/common.rs
@@ -22,6 +22,7 @@ use std::fmt;
 /// not directly associated with an upstream release and will force it to sort higher, e.g.
 /// 0.5.0 vs 0.5.0^deadbeef
 #[derive(Clone, Debug, Default, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EVR {
     pub epoch: String,
     pub version: String,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,8 +5,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::convert::TryInto;
-use std::io::{BufRead, Write};
 use std::hash::{Hash, Hasher};
+use std::io::{BufRead, Write};
 use std::os::unix::prelude::MetadataExt;
 use std::path::{Path, PathBuf};
 
@@ -157,6 +157,7 @@ impl TryInto<CompressionType> for &str {
 // }
 
 #[derive(Clone, Default, Debug, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Package {
     // pub(crate) parse_state: ParseState,
     pub name: String,
@@ -595,6 +596,7 @@ impl Default for ChecksumType {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Checksum {
     Md5(String),
     Sha1(String),
@@ -738,6 +740,7 @@ impl Checksum {
 }
 
 #[derive(Clone, Debug, Default, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Changelog {
     pub author: String,
     pub timestamp: u64,
@@ -745,6 +748,7 @@ pub struct Changelog {
 }
 
 #[derive(Copy, Clone, Debug, Default, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HeaderRange {
     pub start: u64,
     pub end: u64,
@@ -752,6 +756,7 @@ pub struct HeaderRange {
 
 // Requirement (Provides, Conflicts, Obsoletes, Requires).
 #[derive(Clone, Debug, Default, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Requirement {
     pub name: String,
     pub flags: Option<String>,
@@ -800,6 +805,7 @@ impl TryFrom<&str> for RequirementType {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FileType {
     File,
     Dir,
@@ -834,6 +840,7 @@ impl Default for FileType {
 }
 
 #[derive(Clone, Debug, Default, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PackageFile {
     pub filetype: FileType,
     pub path: String,
@@ -875,6 +882,7 @@ impl From<&str> for MetadataType {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DistroTag {
     pub cpeid: Option<String>,
     pub name: String,
@@ -887,6 +895,7 @@ impl DistroTag {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RepomdData {
     revision: Option<String>,
     metadata_files: Vec<RepomdRecord>,
@@ -994,6 +1003,7 @@ impl RepomdData {
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RepomdRecord {
     base_path: Option<PathBuf>,
 
@@ -1064,6 +1074,7 @@ impl RepomdRecord {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateRecord {
     pub from: String,
     pub update_type: String,
@@ -1087,6 +1098,7 @@ pub struct UpdateRecord {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateCollection {
     pub name: String,
     pub shortname: String,
@@ -1095,6 +1107,7 @@ pub struct UpdateCollection {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateReference {
     pub href: String,
     pub id: String,
@@ -1103,6 +1116,7 @@ pub struct UpdateReference {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateCollectionPackage {
     pub epoch: String,
     pub filename: String,
@@ -1118,6 +1132,7 @@ pub struct UpdateCollectionPackage {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UpdateCollectionModule {
     pub name: String,
     pub stream: String,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
 use std::io::{BufRead, Write};
@@ -157,7 +159,7 @@ impl TryInto<CompressionType> for &str {
 // }
 
 #[derive(Clone, Default, Debug, PartialEq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Package {
     // pub(crate) parse_state: ParseState,
     pub name: String,
@@ -596,7 +598,7 @@ impl Default for ChecksumType {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Checksum {
     Md5(String),
     Sha1(String),
@@ -740,7 +742,7 @@ impl Checksum {
 }
 
 #[derive(Clone, Debug, Default, Hash, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Changelog {
     pub author: String,
     pub timestamp: u64,
@@ -748,7 +750,7 @@ pub struct Changelog {
 }
 
 #[derive(Copy, Clone, Debug, Default, Hash, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HeaderRange {
     pub start: u64,
     pub end: u64,
@@ -756,7 +758,7 @@ pub struct HeaderRange {
 
 // Requirement (Provides, Conflicts, Obsoletes, Requires).
 #[derive(Clone, Debug, Default, Hash, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Requirement {
     pub name: String,
     pub flags: Option<String>,
@@ -805,7 +807,7 @@ impl TryFrom<&str> for RequirementType {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum FileType {
     File,
     Dir,
@@ -840,7 +842,7 @@ impl Default for FileType {
 }
 
 #[derive(Clone, Debug, Default, Hash, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PackageFile {
     pub filetype: FileType,
     pub path: String,
@@ -882,7 +884,7 @@ impl From<&str> for MetadataType {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DistroTag {
     pub cpeid: Option<String>,
     pub name: String,
@@ -895,7 +897,7 @@ impl DistroTag {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RepomdData {
     revision: Option<String>,
     metadata_files: Vec<RepomdRecord>,
@@ -1003,7 +1005,7 @@ impl RepomdData {
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RepomdRecord {
     base_path: Option<PathBuf>,
 
@@ -1074,7 +1076,7 @@ impl RepomdRecord {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UpdateRecord {
     pub from: String,
     pub update_type: String,
@@ -1098,7 +1100,7 @@ pub struct UpdateRecord {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UpdateCollection {
     pub name: String,
     pub shortname: String,
@@ -1107,7 +1109,7 @@ pub struct UpdateCollection {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UpdateReference {
     pub href: String,
     pub id: String,
@@ -1116,7 +1118,7 @@ pub struct UpdateReference {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UpdateCollectionPackage {
     pub epoch: String,
     pub filename: String,
@@ -1132,7 +1134,7 @@ pub struct UpdateCollectionPackage {
 }
 
 #[derive(Clone, Debug, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UpdateCollectionModule {
     pub name: String,
     pub stream: String,

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -41,7 +43,7 @@ use indexmap::IndexMap;
 ///
 /// All metadata is maintained in working memory (this can be large).
 #[derive(Debug, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Repository {
     repomd_data: RepomdData,
     packages: IndexMap<String, Package>,

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -41,6 +41,7 @@ use indexmap::IndexMap;
 ///
 /// All metadata is maintained in working memory (this can be large).
 #[derive(Debug, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Repository {
     repomd_data: RepomdData,
     packages: IndexMap<String, Package>,


### PR DESCRIPTION
It's useful if you need to store the repo metadata into a different format. In our case, we're using it serialize it as JSON for Mellisearch.